### PR TITLE
Added service layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 config/database-config.js
+config/facebook-config.js

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const passport = require('passport');
 const configurePassport = require('./config/passport-jwt-config');
 const authController = require('./controllers/auth-controller');
 const userController = require('./controllers/user-controller');
+const facebookAuthController = require('./controllers/facebook-auth-controller');
 
 const app = express();
 app.use(passport.initialize());
@@ -15,5 +16,6 @@ app.use(bodyParser.json());
 
 app.use('/auth', authController);
 app.use('/users', userController);
+app.use('/facebook', facebookAuthController);
 
 app.listen(3000);

--- a/config/facebook-config.js
+++ b/config/facebook-config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    appID: '',
+    secret: ''
+};

--- a/controllers/auth-controller.js
+++ b/controllers/auth-controller.js
@@ -1,31 +1,31 @@
 'use strict';
 
 const express = require('express');
-const jwt = require('jwt-simple');
 const Promise = require('bluebird');
 const User = require('../models/user');
-const securityConfig = require('../config/security-config');
+const authService = require('../services/auth-service');
 
 const router = express.Router();
 
-router.post('/login', function(req, res) {
+router.post('/login', (req, res) => {
     const {username, password} = req.body;
-    Promise.coroutine(function* () {
-        const user = yield User.where('username', username).fetch();
-        const isValidPassword = yield user.validPassword(password);
-        if (isValidPassword) {
-            const token = jwt.encode(user.omit('password'), securityConfig.jwtSecret);
-            res.json({success: true, token: `JWT ${token}`});
-        } else {
-            res.json({success: false, msg: 'Authentication failed'});
-        }
-    })().catch(err => console.log(err));
+    authService.authenticateAndGenerateToken(username, password)
+        .then(token => res.json({ token, success: true }))
+        .catch(error => res.json({ error: 'Authentication failed', success: false }));
 });
 
 router.post('/register', function(req, res) {
     const {username, password} = req.body;
     User.forge({username, password}).save()
-        .then(user => res.json(user.omit('password')));
+        .then(() => { return authService.authenticateAndGenerateToken(username, password) })
+        .then(token => res.json({token, success: true}))
+        .catch(error => {
+            if (error.code === 'ER_DUP_ENTRY') {
+                res.json({ error: 'Username already taken', success: false });
+            } else {
+                res.json({ error: 'User creation failed', success: false });
+            }
+        });
 });
 
 module.exports = router;

--- a/controllers/facebook-auth-controller.js
+++ b/controllers/facebook-auth-controller.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const express = require('express');
+const url = require('url');
+const jwt = require('jwt-simple');
+const User = require('../models/user');
+const facebookConfig = require('../config/facebook-config');
+const uuid = require('node-uuid');
+const Promise = require('bluebird');
+const request = Promise.promisify(require("request"));
+Promise.promisifyAll(request);
+
+const router = express.Router();
+
+router.post('/login', (req, res) => {
+    request(`https://graph.facebook.com/oauth/access_token?client_id=${facebookConfig.appID}&client_secret=${facebookConfig.secret}&grant_type=fb_exchange_token&fb_exchange_token=${req.body.shortLivedToken}`)
+        .then(facebookResponse => {
+            //Parsing the response string is due to the fact that facebook responds to oauth/access_token
+            //with a query string like so: access_token={long-term-token}&expires={expiration}
+            //By adding '?' to the start of that string it can be parsed like a query string
+            const parsedResponseString = url.parse('?' + facebookResponse.body, true).query;
+            const longLivedToken = parsedResponseString.access_token;
+            const expires = parsedResponseString.expires;
+            request('https://graph.facebook.com/me?fields=email,first_name,last_name&access_token=' + longLivedToken)
+            .then(response => {
+                const userInfo = JSON.parse(response.body);
+                User.forge({
+                    username: userInfo.first_name + userInfo.last_name,
+                    password: uuid.v1()
+                }).save()
+                .then(user => res.json(user));
+            })
+        })
+        .catch(err => {
+            console.log(err)
+        });
+});
+
+module.exports = router;

--- a/middleware/roles-authorize.js
+++ b/middleware/roles-authorize.js
@@ -8,6 +8,7 @@ module.exports = function(...authorizedRoles) {
             res.send('Not permitted');
             return;
         }
+
         next();
     }
 };

--- a/models/user.js
+++ b/models/user.js
@@ -11,9 +11,11 @@ module.exports = bookshelf.Model.extend({
     roles() {
         return this.belongsToMany(Role, 'user_role');
     },
+
     validPassword(password) {
         return bcrypt.compareAsync(password, this.attributes.password);
     },
+
     initialize() {
         this.on('saving', model => {
             if (!model.hasChanged('password')) return;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "knex": "^0.10.0",
     "lodash": "^4.6.1",
     "mysql": "^2.10.2",
+    "node-uuid": "^1.4.7",
     "passport": "^0.3.2",
-    "passport-jwt": "^2.0.0"
+    "passport-jwt": "^2.0.0",
+    "request": "^2.69.0"
   }
 }

--- a/services/auth-service.js
+++ b/services/auth-service.js
@@ -1,0 +1,19 @@
+const Promise = require('bluebird');
+const User = require('../models/user');
+const jwt = require('jwt-simple');
+const securityConfig = require('../config/security-config');
+
+module.exports = {
+    authenticateAndGenerateToken(username, password) {
+        return Promise.coroutine(function* () {
+            const user = yield User.where('username', username).fetch();
+            const isValidPassword = yield user.validPassword(password);
+            if (isValidPassword) {
+                const token = jwt.encode(user.omit('password'), securityConfig.jwtSecret);
+                return Promise.resolve(token);
+            } else {
+                return Promise.reject(new Error("Authentication failed"));
+            }
+        })();
+    }
+};


### PR DESCRIPTION
- Created auth-service to handle common tasks that will be reused in auth-controller and facebook-auth-controller

Initial facebook login flow
- Expects a short-term token retrieved from client-side facebook login.
- Exchanges the short-term token for a long-lived token
- Retreives the user's first name, last name, email, and facebook ID.
- Generates a username from the user's name, puts a uuid as the password, as a password won't be used (because they will log in with facebook rather than with a password).
- TODO: Since the username is generated from just a first and last name, we need to handle duplicate names and auto-generate a unique username. i.e. if roblouie is already taken, use roblouie1, and if that is already taken use roblouie2, etc.
